### PR TITLE
small fixes to moff

### DIFF
--- a/tools/moFF/moff.xml
+++ b/tools/moFF/moff.xml
@@ -55,7 +55,7 @@
                     <option value="mzml">mzML</option>
                 </param>
                 <when value="raw">
-                    <param argument="--raw_list" type="@INPUT_TYPE@" multiple="@ALLOW_MULTIPLE@" format="raw" label="RAW file(s)"/>
+                    <param argument="--raw_list" type="@INPUT_TYPE@" multiple="@ALLOW_MULTIPLE@" format="thermo.raw" label="RAW file(s)"/>
                 </when>
                 <when value="mzml">
                     <param argument="--raw_list" type="@INPUT_TYPE@" multiple="@ALLOW_MULTIPLE@" format="mzml" label="mzML file(s)"/>
@@ -174,12 +174,12 @@
         #else if $task.task_selector == "mbr":
            @WRANGLE_IDENT_INPUT_MULTIPLE@
            moff_all.py
-                @IDENT_INPUT_ARG_SINGLE@
+                @IDENT_INPUT_ARG_MULTIPLE@ 
                 --mbr $task.mbr
 				--ext $task.ext
 				--raw_list
            &&
-           mv ./ident_inputs/mbr_output/* ./out
+           mv ./mbr_output/* ./out
         #else:
            ## moff_all (mbr followed by apex)
            @WRANGLE_IDENT_INPUT_MULTIPLE@


### PR DESCRIPTION
- raw datatype was updated to thermo.raw some time ago as far as I could check.
- changed the mv paths in the out dir.
- in the case of mbr analysis, since the input is a collection you have to iterate over the elements to pass them to --tsv_list, therefore I replaced  @IDENT_INPUT_ARG_SINGLE@ with @IDENT_INPUT_ARG_MULTIPLE@
The token naming seems to be wrong though 